### PR TITLE
Replace rest-client with http.rb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@
 
 ### Changes
 
+* [PR](https://github.com/Neodelf/lecter/pull/68): Replace Rest-client with http.rb ([@oskaror][])
 * [PR](https://github.com/Neodelf/lecter/pull/69): Set the simplecov gem version to 0.17.1 ([@neodelf][])
 * [commit](https://github.com/Neodelf/lecter/commit/73e0ed69cf8e1773abed9e9b735e0742aa63dade): Update makeup. ([@neodelf][])
 
+[@oskaror]: https://github.com/oskaror
 [@neodelf]: https://github.com/neodelf

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,36 +2,42 @@ PATH
   remote: .
   specs:
     lecter (0.1.6)
-      rest-client
+      http
       simplecov (= 0.17.1)
 
 GEM
   remote: https://rubygems.org/
   specs:
+    addressable (2.8.0)
+      public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.0)
     diff-lcs (1.3)
-    docile (1.3.2)
+    docile (1.4.0)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
-    http-accept (1.7.0)
-    http-cookie (1.0.3)
+    ffi (1.15.5)
+    ffi-compiler (1.0.1)
+      ffi (>= 1.0.0)
+      rake
+    http (5.0.4)
+      addressable (~> 2.8)
+      http-cookie (~> 1.0)
+      http-form_data (~> 2.2)
+      llhttp-ffi (~> 0.4.0)
+    http-cookie (1.0.4)
       domain_name (~> 0.5)
+    http-form_data (2.3.0)
     jaro_winkler (1.5.4)
-    json (2.3.0)
-    mime-types (3.3.1)
-      mime-types-data (~> 3.2015)
-    mime-types-data (3.2019.1009)
-    netrc (0.11.0)
+    json (2.6.1)
+    llhttp-ffi (0.4.0)
+      ffi-compiler (~> 1.0)
+      rake (~> 13.0)
     parallel (1.19.1)
     parser (2.7.1.0)
       ast (~> 2.4.0)
+    public_suffix (4.0.6)
     rainbow (3.0.0)
     rake (13.0.1)
-    rest-client (2.1.0)
-      http-accept (>= 1.7.0, < 2.0)
-      http-cookie (>= 1.0.2, < 2.0)
-      mime-types (>= 1.16, < 4.0)
-      netrc (~> 0.8)
     rexml (3.2.5)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
@@ -62,7 +68,7 @@ GEM
     simplecov-html (0.10.2)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.7.7)
+    unf_ext (0.0.8)
     unicode-display_width (1.7.0)
 
 PLATFORMS

--- a/lecter.gemspec
+++ b/lecter.gemspec
@@ -36,6 +36,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rubocop'
 
-  spec.add_runtime_dependency 'rest-client'
+  spec.add_runtime_dependency 'http'
   spec.add_runtime_dependency 'simplecov', '0.17.1'
 end

--- a/lib/lecter.rb
+++ b/lib/lecter.rb
@@ -10,7 +10,7 @@ require 'lecter/requester'
 require 'lecter/version'
 require 'lecter/trace_point'
 
-require 'rest-client'
+require 'http'
 
 module Lecter
   AVAILABLE_METHODS = %w[GET POST PUT PATCH DELETE].freeze

--- a/lib/lecter/requester.rb
+++ b/lib/lecter/requester.rb
@@ -20,7 +20,7 @@ module Lecter
     rescue URI::InvalidURIError
       @error_message = WRONG_URL_MSG
       false
-    rescue RestClient::ExceptionWithResponse => e
+    rescue HTTP::Error => e
       @error_message = e.message
       false
     end
@@ -43,15 +43,11 @@ module Lecter
     end
 
     def response
-      @response ||= RestClient::Request.execute(
-        method: method,
-        url: url,
-        payload: payload
-      )
+      @response ||= HTTP.public_send(method, url, body: payload.to_json)
     end
 
     def items
-      @items ||= response.body[3..-1].split(';')
+      @items ||= response.body.to_s[3..-1].split(';')
     end
 
     def line_belongs_to_last?(file)

--- a/spec/requester_spec.rb
+++ b/spec/requester_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Lecter::Requester do
   let(:specific_parameter) { { lecter_enabled: true } }
   let(:url) { 'localhost:3009/posts' }
   let(:payload) { { 'post' => { 'title' => 'New title', 'description' => 'New description' } } }
-  let(:params) { { method: :anything, url: url, payload: payload, lecter_enabled: true } }
+  let(:params) { { method: :get, url: url, payload: payload, lecter_enabled: true } }
   let(:instance) { described_class.new(params) }
 
   subject { instance.call }
@@ -14,7 +14,7 @@ RSpec.describe Lecter::Requester do
   context 'if all params are valid' do
     before do
       response = instance_double(
-        RestClient::Response,
+        HTTP::Response,
         body: "\
 302/absolute_path_to_app/app/controllers/posts_controller.rb 26 PostsController create call;\
 /absolute_path_to_app/app/controllers/posts_controller.rb 27 PostsController create line;\
@@ -28,7 +28,7 @@ absolute_path_to_app/app/controllers/posts_controller.rb 29 PostsController crea
 /absolute_path_to_app/app/controllers/posts_controller.rb 31 PostsController create line;\
 /absolute_path_to_app/app/controllers/posts_controller.rb 38 PostsController create return;"
       )
-      allow(RestClient::Request).to receive(:execute).and_return(response)
+      allow(HTTP).to receive(:get).and_return(response)
       subject
     end
 
@@ -44,10 +44,10 @@ absolute_path_to_app/app/controllers/posts_controller.rb 29 PostsController crea
     end
   end
 
-  [RestClient::ExceptionWithResponse, URI::InvalidURIError].each do |error|
+  [HTTP::RequestError, URI::InvalidURIError].each do |error|
     context "if raise #{error}" do
       before do
-        allow(RestClient::Request).to receive(:execute).and_raise(error)
+        allow(HTTP).to receive(:get).and_raise(error)
       end
 
       it 'returns false' do


### PR DESCRIPTION
Fix #21
Currently, we use the rest-client gem, but it's a very heavy-weight library, so I replaced it with [http.rb](https://github.com/httprb/http)

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.

[1]: https://chris.beams.io/posts/git-commit/
