### PR TITLE
Redirect from /lecter to /lecter/diagnosis/new

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
 Lecter::Engine.routes.draw do
+  root 'diagnosis#new'
+
   resource :diagnosis, only: %w[new create show], controller: :diagnosis
 end


### PR DESCRIPTION
[Fix #50] Add root route to redirect from `/lecter` to `/lecter/diagnosis/new`

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.

[1]: https://chris.beams.io/posts/git-commit/
